### PR TITLE
This is an attempt at add caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.aider*
+openai.logs
+.gitignore
+.git

--- a/aot/main.py
+++ b/aot/main.py
@@ -1,5 +1,5 @@
 from aot.openai import OpenAI
-
+import json
 import logging
 
 logging.basicConfig(
@@ -18,7 +18,12 @@ class AoT:
         backtracking_threshold=0.4,
         initial_prompt=None,
         openai_api_key: str = None,
+        thought_cache=None  # Set to None here
     ):
+        if thought_cache is None:
+            self.thought_cache = {'accepted': {}, 'pruned': {}}
+        else:
+            self.thought_cache = thought_cache
         self.num_thoughts = num_thoughts
         self.max_steps = max_steps
         self.value_threshold = value_threshold
@@ -31,44 +36,99 @@ class AoT:
 
     def solve(self):
         try:
+            # Run DFS
             self.dfs(self.initial_prompt, 1)
 
+            # Check if any thoughts were generated
             if not self.output:
                 logger.error("No valid thoughts were generated during DFS")
                 return None
 
-            best_state, _ = max(self.output, key=lambda x: x[1])
+            # Find the best thought and its value
+            best_state, best_value = max(self.output, key=lambda x: x[1])
+
+            # Cache the best thought
+            self.thought_cache['accepted'][best_state] = best_value
+
+            # Generate the final solution based on the best thought
             solution = self.model.generate_solution(self.initial_prompt, best_state)
+
+            # Display and return the solution
             print(f"Solution is {solution}")
+
+            # Write cache to JSON file
+            # Change back to 'w' if you want to overwrite the file
+            with open('./thought_cache.json', 'a') as json_file:
+                json.dump(self.thought_cache, json_file)
+
             return solution if solution else best_state
+
         except Exception as error:
             logger.error(f"Error in tot_dfs: {error}")
+
+            # Write cache to JSON file even if an error occurs
+            # Change back to 'w' if you want to overwrite the file
+            with open('./thought_cache_error.json', 'a') as json_file:
+                json.dump(self.thought_cache, json_file)
+
             raise error
 
     def dfs(self, state, step):
         if step > self.max_steps:
-            thought, value = self.evaluate_thought(state)
-            self.output.append((thought, value))
+            # Check cache before evaluating
+            if state in self.thought_cache['accepted']:
+                value = self.thought_cache['accepted'][state]
+            elif state in self.thought_cache['pruned']:
+                return
+            else:
+                thought, value = self.evaluate_thought(state)
+                # Cache the evaluated thought
+                self.thought_cache['accepted'][state] = value
+            
+            self.output.append((state, value))
             return
 
-        thoughts = self.generate_and_filter_thoughts(state)
-        for next_state in thoughts:
-            state_value = self.evaluated_thoughts[next_state]
-            if state_value > self.value_threshold:
-                child = (
-                    (state, next_state)
-                    if isinstance(state, str)
-                    else (*state, next_state)
-                )
-                self.dfs(child, step + 1)
+        # Check cache before generating and filtering
+        if state in self.thought_cache['accepted']:
+            thoughts = [state]
+        elif state in self.thought_cache['pruned']:
+            return
+        else:
+            thoughts = self.generate_and_filter_thoughts(state)
 
-                # backtracking
-                best_value = max([value for _, value in self.output])
-                if best_value < self.backtracking_threshold:
-                    self.output.pop()
-                    continue
+        for next_state in thoughts:
+            state_value = self.evaluated_thoughts.get(next_state, 0)
+            print("Entering DFS with state: ", state, " and step: ", step)
+
+            # Cache pruned thoughts
+            if state_value <= self.value_threshold:
+                self.thought_cache['pruned'][next_state] = state_value
+                continue
+
+            # Proceed with DFS
+            child = (
+                (state, next_state)
+                if isinstance(state, str)
+                else (*state, next_state)
+            )
+            self.dfs(child, step + 1)
+
+            # Backtracking
+            best_value = max([value for _, value in self.output])
+            if best_value < self.backtracking_threshold:
+                self.output.pop()
+                continue
 
     def generate_and_filter_thoughts(self, state):
+        # Check if thoughts for this state are cached
+        if state in self.thought_cache['accepted']:
+            print(f"Retrieved accepted thoughts from cache for state: {state}")
+            return [state]
+        elif state in self.thought_cache['pruned']:
+            print(f"Retrieved pruned thoughts from cache for state: {state}")
+            return []
+
+        # Else generate new thoughts
         thoughts = self.model.generate_thoughts(
             state, self.num_thoughts, self.initial_prompt
         )
@@ -82,11 +142,41 @@ class AoT:
             for thought in thoughts
             if self.evaluated_thoughts[thought] >= self.pruning_threshold
         ]
+
+        # Cache the filtered thoughts
+        for thought in filtered_thoughts:
+            self.thought_cache['accepted'][thought] = self.evaluated_thoughts[thought]
+
+        for thought in thoughts:
+            if self.evaluated_thoughts[thought] < self.pruning_threshold:
+                self.thought_cache['pruned'][thought] = self.evaluated_thoughts[thought]
+
+        print("Generated Thoughts: ", thoughts)
+        print("Evaluated Thoughts: ", self.evaluated_thoughts)
+
         print(f"filtered_thoughts: {filtered_thoughts}")
         return filtered_thoughts
 
     def evaluate_thought(self, state):
+        # Check if the thought is already in the cache
+        if state in self.thought_cache['accepted']:
+            value = self.thought_cache['accepted'][state]
+            print(f"Retrieved accepted thought value from cache: {value}")
+            return state, value
+        elif state in self.thought_cache['pruned']:
+            value = 0  # or whatever value you use for pruned thoughts
+            print(f"Retrieved pruned thought value from cache: {value}")
+            return state, value
+
+        # Otherwise, evaluate the thought
         thought = self.model.generate_thoughts(state, 1, self.initial_prompt)
         value = self.model.evaluate_states([state], self.initial_prompt)[state]
+
+        # Update the cache based on the evaluation
+        if value >= self.pruning_threshold:
+            self.thought_cache['accepted'][state] = value
+        else:
+            self.thought_cache['pruned'][state] = value
+
         print(f"Evaluated thought: {value}")
         return thought, value

--- a/aot/openai.py
+++ b/aot/openai.py
@@ -21,10 +21,18 @@ class OpenAI:
     ):
         if api_key == "" or api_key is None:
             api_key = os.environ.get("OPENAI_API_KEY", "")
-        if api_key != "":
-            openai.api_key = api_key
-        else:
+        
+        if api_key == "":
+            try:
+                with open(os.path.expanduser('~/some/defined/path'), 'r') as f:
+                    api_key = f.read().strip()
+            except FileNotFoundError:
+                pass  # Handle the exception as you see fit
+
+        if api_key == "":
             raise Exception("Please provide OpenAI API key")
+        else:
+            openai.api_key = api_key
 
         if api_base == "" or api_base is None:
             api_base = os.environ.get(
@@ -40,7 +48,7 @@ class OpenAI:
         if api_model != "":
             self.api_model = api_model
         else:
-            self.api_model = "text-davinci-003"
+            self.api_model = "gpt-3.5-turbo"
         print(f"Using api_model {self.api_model}")
 
         self.use_chat_api = "gpt" in self.api_model
@@ -160,6 +168,7 @@ class OpenAI:
                 if type(state) == str:
                     state_text = state
                 else:
+                    print(f"state: {state}")
                     state_text = "\n".join(state)
                 print(
                     "We receive a state of type",

--- a/examples.py
+++ b/examples.py
@@ -33,7 +33,7 @@ dfs = AoT(
     max_steps=10,
     value_threshold=1,
     initial_prompt=task,
-    openai_api_key="ENETER IN YOUR API KEY",
+    #openai_api_key="ENETER IN YOUR API KEY",
 )
 
 result = dfs.solve()

--- a/neural_search_example.py
+++ b/neural_search_example.py
@@ -68,7 +68,7 @@ dfs = AoT(
     max_steps=10,
     value_threshold=1,
     initial_prompt=system,
-    openai_api_key="ENETER IN YOUR API KEY",
+    #openai_api_key="ENETER IN YOUR API KEY",
 )
 
 result = dfs.solve()


### PR DESCRIPTION
feat: Implement Thought Caching for DFS Algorithm

This commit introduces a caching mechanism for the Depth-First Search (DFS) algorithm used in thought generation. By caching the evaluated thoughts, the algorithm can now make more informed decisions, leading to more efficient and accurate solutions.

- Add `thought_cache` dictionary to the AoT class to store 'accepted' and 'pruned' thoughts.
- Update `dfs`, `generate_and_filter_thoughts`, and `evaluate_thought` methods to utilize `thought_cache`.
- Add functionality to serialize the `thought_cache` to a JSON file for persistence across multiple runs.
- Fix minor bugs related to API key retrieval and error logging.

This enhancement improves the algorithm's performance and makes it more robust for complex problem-solving tasks.
